### PR TITLE
[Fix] ヘッダから飛ぶページのタイトルを消す

### DIFF
--- a/_includes/category_cloud.html
+++ b/_includes/category_cloud.html
@@ -10,6 +10,8 @@
     {% assign categories_name = categories_name | sort %}
 {% endif %}
 
+<h3>Categories</h3>
+
 <ul class="tag-cloud">
 {% for category_name in categories_name %}
   <li>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,10 +3,6 @@ layout: default
 ---
 <article class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">{{ page.title | escape }}</h1>
-  </header>
-
   <div class="post-content">
     {{ content }}
   </div>

--- a/_site/about/index.html
+++ b/_site/about/index.html
@@ -80,10 +80,6 @@
       <div class="wrapper">
         <article class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">About</h1>
-  </header>
-
   <div class="post-content">
     <h1 id="experience-pointsの特徴">eXperience Pointsの特徴</h1>
 <ul>

--- a/_site/assets/main.css
+++ b/_site/assets/main.css
@@ -531,10 +531,10 @@ table {
         text-decoration: none; }
 
 .post-summary {
-  border-bottom: solid 2px #E4E6EB; }
+  border-bottom: solid 1px #E4E6EB; }
 
 .post-summary:first-child {
-  border-top: solid 2px #E4E6EB;
+  border-top: solid 1px #E4E6EB;
   padding-top: 1em; }
 
 #category-post-list-item {
@@ -546,3 +546,13 @@ table {
 
 .posts-by-categories {
   margin-top: 1em; }
+
+.post-title {
+  font-size: 26pt !important; }
+
+.post-header {
+  border-bottom: solid 1px #E4E6EB; }
+
+.posts-by-categories {
+  padding-top: 1em;
+  border-top: solid 1px #E4E6EB !important; }

--- a/_site/mining/index.html
+++ b/_site/mining/index.html
@@ -80,10 +80,6 @@
       <div class="wrapper">
         <article class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">Mining</h1>
-  </header>
-
   <div class="post-content">
     <h1 id="xp疑似マイニング">XP疑似マイニング</h1>
 <p>このサイトでマイニングできます <a href="https://pool1.xpcoin.io/">https://pool1.xpcoin.io/</a></p>

--- a/_site/wallet/index.html
+++ b/_site/wallet/index.html
@@ -80,10 +80,6 @@
       <div class="wrapper">
         <article class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">Wallet</h1>
-  </header>
-
   <div class="post-content">
     <h1 id="xp-walletについて">XP Walletについて</h1>
 <ul>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -55,11 +55,11 @@ $border-color: #E4E6EB;
 }
 
 .post-summary {
-    border-bottom: solid 2px $border-color;
+    border-bottom: solid 1px $border-color;
 }
 
 .post-summary:first-child {
-    border-top: solid 2px $border-color;
+    border-top: solid 1px $border-color;
     padding-top: 1em;
 }
 
@@ -74,4 +74,17 @@ $border-color: #E4E6EB;
 
 .posts-by-categories {
     margin-top: 1em;
+}
+
+.post-title {
+    font-size: 26pt !important;
+}
+
+.post-header {
+    border-bottom: solid 1px $border-color;
+}
+
+.posts-by-categories {
+    padding-top: 1em;
+    border-top: solid 1px $border-color !important;
 }

--- a/categories.html
+++ b/categories.html
@@ -14,8 +14,6 @@ permalink: /categories
 
 {% include category_cloud.html categories_name = categories_name %}
 
-<hr>
-
 <section class="posts-by-categories">
   {% for category_name in categories_name %}
     <div>


### PR DESCRIPTION
ヘッダから飛ぶページではコンテンツにおいて階層構造ができているため新たに上位層でタイトルを表示する必要がないと判断したため消した